### PR TITLE
Remove Bless Unleashed

### DIFF
--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -21,6 +21,9 @@
 "381780": # 80 Days
   compat_tool: proton_513
 
+"668550": # 8Doors: Arum's Afterlife Adventure
+  compat_tool: proton_63
+
 "499890": # Aaero
   compat_tool: proton_411
 

--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -213,9 +213,6 @@
 "702890": # BlazBlue: Cross Tag Battle
   compat_tool: proton_513
 
-"1254120": # Bless Unleashed
-  compat_tool: proton_513
-
 "1015930": # Blood Rage Digital Edition
   compat_tool: proton_513
 


### PR DESCRIPTION
Remove Bless Unleashed as it has enabled EAC on Win only so far.