### PR TITLE
Add Assetto Corsa Competizione

### DIFF
--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -99,7 +99,7 @@
 "1109690": # Asterix & Obelix XXL 3 - The Crystal Menhir
   compat_tool: proton_63
 
-"80555": # Assetto Corsa Competizione
+"805550": # Assetto Corsa Competizione
   compat_tool: proton_63
 
 "757320": # Atomicrops

--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -99,6 +99,9 @@
 "1109690": # Asterix & Obelix XXL 3 - The Crystal Menhir
   compat_tool: proton_63
 
+"80555": # Assetto Corsa Competizione
+  compat_tool: proton_63
+
 "757320": # Atomicrops
   compat_tool: Proton-6.16-GE-1
 


### PR DESCRIPTION
Works fine with Proton 6.3-8. Some performance inconsistencies but rare and playable.