### PR TITLE
Humble Bundle January / Fix Lego Ninjago sound issues

### DIFF
--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -995,6 +995,9 @@
 "40700": # Machinarium
   compat_tool: proton_513
 
+"1030840": # Mafia: Definitive Edition
+  compat_tool: Proton-6.21-GE-2
+
 "529660": # Mages of Mystralia
   compat_tool: Proton-6.1-GE-2
   compat_config: wined3d

--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -809,6 +809,9 @@
 "230150": # Incredipede
   compat_tool: proton_513
 
+"826630": # Iron Harvest
+  compat_tool: Proton-6.21-GE-2
+
 "224900": # Iron Sky Invasion; native version doesn't work anymore
   compat_tool: proton_513
 

--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -996,7 +996,8 @@
   compat_tool: proton_513
 
 "1030840": # Mafia: Definitive Edition
-  compat_tool: Proton-6.21-GE-2
+  compat_tool: proton_63
+  launch_options: eval $( echo "%command%" | sed "s/2KLauncher\/LauncherPatcher.exe'.*/mafiadefinitiveedition.exe'/" )
 
 "529660": # Mages of Mystralia
   compat_tool: Proton-6.1-GE-2

--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -926,6 +926,7 @@
 
 "640590": # The LEGO NINJAGO Movie Video Game
   compat_tool: proton_63
+  launch_options: WINEDLLOVERRIDES="xaudio2_7=native,builtin" %command%
 
 "311770": # LEGO Pirates of the Caribbean The Video Game
   compat_tool: proton_411
@@ -1298,6 +1299,9 @@
 "895870": # Project Wingman
   compat_tool: proton_6.20-GE-1
 
+"774861": # Project Winter
+  compat_tool: proton_63
+
 "607080": # Psychonauts 2
   compat_tool: proton_63
   launch_options: -force -dx11
@@ -1366,6 +1370,9 @@
 
 "290040": # Retro Game Crunch
   compat_tool: proton_513
+
+"1239690": # Retrowave
+  compat_tool: proton_63
 
 "1152020": # Return Of The Zombie King
   compat_tool: proton_63


### PR DESCRIPTION
- Added 3remaining working Humble Bundle Games
- Bypassed buggy 2K launcher of Mafia complete edition
- Fixed very noisy sound in some areas in Lego Ninjago