### PR TITLE
Update and Fix Hellblade: Senua's Sacrifice

### DIFF
--- a/tweaks/steam.yaml
+++ b/tweaks/steam.yaml
@@ -775,7 +775,8 @@
   launch_options: WINEDLLOVERRIDES="xaudio2_7=native,builtin" %command%
 
 "414340": # Hellblade: Senua's Sacrifice
-  compat_tool: proton_411
+  compat_tool: proton_63
+  launch_options: -dx11
 
 "521890": # Hello Neighbour
   compat_tool: proton_411


### PR DESCRIPTION
Wont launch in dx12 mode, needs launch option "-dx11".