### PR TITLE
Set microSD as supported on the ROG Ally

### DIFF
--- a/hwdb.yaml
+++ b/hwdb.yaml
@@ -166,7 +166,7 @@
   suspend: unsupported
   finger_print_reader: unsupported
   gyro: unsupported
-  micro_sd: unknown
+  micro_sd: supported
   video_out: supported
   ethernet: supported
   tdp_control: unsupported


### PR DESCRIPTION
After testing with 2 microSD cards it seems to be working on the Ally. 
I tried a new card that was unused and one that had been used in a steam deck, both worked perfectly with hotswap support and gets mounted in gamemode automatically.
I also tried playing these games from both SD cards and that works fine too