### PR TITLE
Enable Baldur's Gate Split-Screen On Non Steam Deck Devices.

### DIFF
--- a/gamedb.yaml
+++ b/gamedb.yaml
@@ -3704,8 +3704,8 @@
   status: verified
   store: humble:bad-north-jotunn-edition
 
-# SteamDeck=0 to fix inability to trigger split-screen mode. --skip-launcher to maintain console compatabilty
-- name: 'Baldur''s Gate 3'
+# SteamDeck=0 to fix inability to trigger split-screen mode. --skip-launcher to maintain console compatibility
+- name: "Baldur's Gate 3"
   platform: steam
   id: 1086940
   launch_options: SteamDeck=0 %command% --skip-launcher

--- a/gamedb.yaml
+++ b/gamedb.yaml
@@ -3704,6 +3704,12 @@
   status: verified
   store: humble:bad-north-jotunn-edition
 
+# SteamDeck=0 to fix inability to trigger split-screen mode. --skip-launcher to maintain console compatabilty
+- name: 'Baldur''s Gate 3'
+  platform: steam
+  id: 1086940
+  launch_options: SteamDeck=0 %command% --skip-launcher
+
 - name: 'GRIP: Combat Racing'
   platform: steam
   id: 396900


### PR DESCRIPTION
Baldur's Gate 3 has to launch with "SteamDeck=0 %command%" and "--skip-launcher" in order for Split-Screen functionality to be enabled.

Without the Steam Deck 0 command it is not possible to activate the split screen mode. With the Steam Deck 0 command Larian's launcher pops upon launching the game.