### PR TITLE
Set EA WRC as unsupported

### DIFF
--- a/gamedb.yaml
+++ b/gamedb.yaml
@@ -1937,6 +1937,12 @@
   id: 239140
   status: verified
 
+ # Since version 1.9.0 it has EA Anticheat, can't play it anymore
+- name: "EA Sports WRC"
+  platform: steam
+  id: 1849250
+  status: unsupported
+
 - name: "EARTHLOCK"
   platform: steam
   id: 761030
@@ -6905,12 +6911,6 @@
   platform: steam
   id: 327030
   launch_options: LD_LIBRARY_PATH= %command%
-
- # Since version 1.9.0 it has EA Anticheat, can't play it anymore
-- name: "EA Sports WRC"
-  platform: steam
-  id: 1849250
-  status: unsupported
 
 - name: "WWE 2K BATTLEGROUNDS"
   platform: steam

--- a/gamedb.yaml
+++ b/gamedb.yaml
@@ -6906,12 +6906,11 @@
   id: 327030
   launch_options: LD_LIBRARY_PATH= %command%
 
- # Disable -steamdeck to fix the game refusing to launch
-- name: "WRC"
+ # Since version 1.9.0 it has EA Anticheat, can't play it anymore
+- name: "EA Sports WRC"
   platform: steam
   id: 1849250
-  status: verified
-  launch_options: SteamDeck=0 %command%
+  status: unsupported
 
 - name: "WWE 2K BATTLEGROUNDS"
   platform: steam


### PR DESCRIPTION
Since version 1.9.0 they introduced Kernel level anticheat (EA Anticheat). It won't even launch