### PR TITLE
disable PSN on Horizon Zero Dawn Remastered

### DIFF
--- a/gamedb.yaml
+++ b/gamedb.yaml
@@ -3153,6 +3153,12 @@
   store: humble:horizon-zero-dawn-complete-edition
   status: verified
 
+# -showlinkingqr to disable PSN requirement, which disables the overlay, which allows it to play
+- name: "Horizon Zero Dawn Remastered"
+  platform: steam
+  id: 2561580
+  launch_options: -showlinkingqr
+
 - name: "Hot Wheels Unleashed"
   platform: steam
   id: 1271700


### PR DESCRIPTION
Horizon Zero Dawn Remastered has a PSN requirement, which won't work on Linux. This command disables that requirement to allow it to play as normal.

https://www.gamingonlinux.com/2024/10/horizon-zero-dawn-remastered-may-need-a-workaround-on-desktop-linux/